### PR TITLE
Add params to analyze task to toggle interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ VERSION:
    0.0.3
 
 COMMANDS:
-   analyze     Analyze and interact one or more URLs for phishing
+   analyze     Analyze one or more URLs for phishing
    collect     Collect HTML and assets for one or more URLs
    screenshot  Screenshot one or more URLs
    help, h     Shows a list of commands or help for one command
@@ -74,7 +74,7 @@ All commands accept the following flags:
    --help, -h                  show help
 ```
 
-See command-specific help for output flags.
+See command-specific help for output and additional task specific flags.
 
 The `--remote` flag will use a `RemoteAllocator`. It's primarily used
 with the [`chromedp` headless shell

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -58,6 +58,10 @@ func main() {
 		&cli.IntFlag{Name: "wait", Value: 300, Aliases: []string{"w"}, Usage: "wait time (seconds) after load before analysis"},
 	}, withOutputFlags...)
 
+	analyzeFlags := append([]cli.Flag{
+		&cli.BoolFlag{Name: "no-clipboard", Usage: "disable clipboard interactions"},
+	}, withWaitFlags...)
+
 	ver := version
 	if ver == "" {
 		ver = "0.0.0"
@@ -66,26 +70,29 @@ func main() {
 	cmd := &cli.Command{
 		Name:    "pisces",
 		Version: ver,
-		Usage:   "A tool for analyzing phishing sites",
+		Usage:   "A tool for analyzing phishing sites.",
 		Commands: []*cli.Command{
 			{
-				Name:      "analyze",
-				Usage:     "Analyze and interact one or more URLs for phishing",
-				Arguments: baseArgs,
-				Flags:     withWaitFlags,
+				Name:        "analyze",
+				Usage:       "Analyze one or more URLs for phishing",
+				Description: "In addition to capturing requests, this task extracts cookies, links, forms, and inputs from the page. This task can optionally run simga detection rules. The task will also interact with the page:\n - Click elements looking for event handlers that copy to the clipboard.",
+				Arguments:   baseArgs,
+				Flags:       analyzeFlags,
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					params := map[string]any{
-						"wait": cmd.Int("wait"),
+						"clipboard": !cmd.Bool("no-clipboard"),
+						"wait":      cmd.Int("wait"),
 					}
 
 					return runTask(ctx, cmd, "analyze", params, outputResultJson)
 				},
 			},
 			{
-				Name:      "collect",
-				Usage:     "Collect HTML and assets for one or more URLs",
-				Arguments: baseArgs,
-				Flags:     withOutputFlags,
+				Name:        "collect",
+				Usage:       "Collect HTML and assets for one or more URLs",
+				Description: "This task will capture all assets included by the page. Request and response headers as well as full response bodies are included in the results. This task can optionally run sigma detection rules.",
+				Arguments:   baseArgs,
+				Flags:       withOutputFlags,
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					return runTask(ctx, cmd, "collect", map[string]any{}, outputResultJson)
 				},

--- a/engine/task.go
+++ b/engine/task.go
@@ -80,6 +80,20 @@ func (t Task) IntParam(key string, defaultVal int) int {
 	return n
 }
 
+func (t Task) BoolParam(key string, defaultVal bool) bool {
+	val, ok := t.params[key]
+	if !ok {
+		return defaultVal
+	}
+
+	n, ok := val.(bool)
+	if !ok {
+		return defaultVal
+	}
+
+	return n
+}
+
 type Result struct {
 	Action  string        `json:"action"`
 	Elapsed time.Duration `json:"elapsed"`

--- a/engine/task_analyze_test.go
+++ b/engine/task_analyze_test.go
@@ -25,6 +25,11 @@ func TestPerformAnalyzeTask(t *testing.T) {
 	assert.Equal(t, "A Simple Web Page", ar.InitialTitle)
 	assert.Equal(t, "A Simple Web Page", ar.Head.Title)
 	assert.Equal(t, "Simple Page Hello world!", ar.VisibleText)
+	assert.Equal(t, []string{}, ar.ClipboardTexts)
+	assert.Equal(t, []Cookie{}, ar.Cookies)
+	assert.Equal(t, []string{}, ar.CookiePairs)
+	assert.Equal(t, []Form{}, ar.Forms)
+	assert.Equal(t, []Link{}, ar.Links)
 }
 
 func TestPerformAnalyzeTaskWithCookeis(t *testing.T) {
@@ -94,6 +99,20 @@ func TestPerformAnalyzeTaskWithTitleChange(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "Initial Title", ar.InitialTitle)
 	assert.Equal(t, "Set by JS", ar.Head.Title)
+}
+
+func TestPerformAnalyzeTaskWithClipboardInteractionsWithClipboardParamFalse(t *testing.T) {
+	server := piscestest.NewTestWebServer("fakecaptcha")
+	task := NewTask("analyze", server.URL)
+	task.params = map[string]any{"clipboard": false}
+
+	ctx, cancel := piscestest.NewTestContext()
+	defer cancel()
+
+	ar, err := performAnalyzeTask(ctx, &task, pisces.Logger())
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{}, ar.ClipboardTexts)
 }
 
 func TestPerformAnalyzeTaskWithClipboardInteractions(t *testing.T) {

--- a/engine/task_test.go
+++ b/engine/task_test.go
@@ -111,6 +111,53 @@ func TestNewTask(t *testing.T) {
 	}
 }
 
+func TestTaskBoolParam(t *testing.T) {
+	tests := []struct {
+		name        string
+		params      map[string]any
+		key         string
+		defaultVal  bool
+		expectedVal bool
+	}{
+		{
+			name:        "existing bool parameter",
+			params:      map[string]any{"enabled": false},
+			key:         "enabled",
+			defaultVal:  true,
+			expectedVal: false,
+		},
+		{
+			name:        "missing parameter returns default",
+			params:      map[string]any{},
+			key:         "enabled",
+			defaultVal:  true,
+			expectedVal: true,
+		},
+		{
+			name:        "zero value bool parameter",
+			params:      map[string]any{"enabled": false},
+			key:         "enabled",
+			defaultVal:  true,
+			expectedVal: false,
+		},
+		{
+			name:        "non-bool parameter returns default",
+			params:      map[string]any{"timeout": "30"},
+			key:         "timeout",
+			defaultVal:  true,
+			expectedVal: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := NewTask("test", "http://example.com", WithParams(tt.params))
+			result := task.BoolParam(tt.key, tt.defaultVal)
+			assert.Equal(t, tt.expectedVal, result)
+		})
+	}
+}
+
 func TestTaskIntParam(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
This adds a task parameter to toggle clipboard interactions. All interactions will be enabled by default and we can use additional bool parameter for more interaction toggles (ie: for forms).

As far as the CLI tool goes, the clipboard interaction is disabled by providing the `--no-clipboard` flag to the `analyze` task.